### PR TITLE
SWAP-1202 Keep track of the deployed versions

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -45,5 +45,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          build-args: BUILD_VERSION=${{ github.sha }}
           push: true
           tags: dmsc/duo-factory:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,14 +1,13 @@
 name: Test && Build && Push
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the develop branch
+# events but only for the develop and master branches
 on:
   pull_request:
     branches: [develop, master]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ uploads
 !example.env
 
 codegen_tmp.yml
+
+build-version*.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ COPY --chown=pptruser:pptruser ./templates ./templates
 
 RUN npm ci --only=production --loglevel error --no-fund
 
+ARG BUILD_VERSION=<unknown>
+RUN echo $BUILD_VERSION > build-version.txt
+
 EXPOSE 4500
 
 CMD [ "node", "./build/index.js" ]

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 
+import { readFile } from 'fs';
 import { join } from 'path';
 
 import { logger } from '@esss-swap/duo-logger';
@@ -44,6 +45,31 @@ app.get('/test-template/:template', (req, res, next) => {
       res.end();
     })
     .catch(e => next(e));
+});
+
+let cached: string;
+
+app.get('/version', (req, res) => {
+  if (cached) {
+    return res.end(cached);
+  }
+
+  readFile(join(process.cwd(), 'build-version.txt'), (err, content) => {
+    if (err) {
+      if (err.code !== 'ENOENT') {
+        logger.logException(
+          'Unknown error while reading build-version.txt',
+          err
+        );
+      }
+
+      return res.end('<unknown>');
+    }
+
+    cached = content.toString().trim();
+
+    res.end(cached);
+  });
 });
 
 app.get('/', (req, res) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -47,11 +47,11 @@ app.get('/test-template/:template', (req, res, next) => {
     .catch(e => next(e));
 });
 
-let cached: string;
+let cachedVersion: string;
 
 app.get('/version', (req, res) => {
-  if (cached) {
-    return res.end(cached);
+  if (cachedVersion) {
+    return res.end(cachedVersion);
   }
 
   readFile(join(process.cwd(), 'build-version.txt'), (err, content) => {
@@ -66,9 +66,9 @@ app.get('/version', (req, res) => {
       return res.end('<unknown>');
     }
 
-    cached = content.toString().trim();
+    cachedVersion = content.toString().trim();
 
-    res.end(cached);
+    res.end(cachedVersion);
   });
 });
 


### PR DESCRIPTION
## Description

This PR adds support for requesting the current build version of the user office factory.
<!--- Describe your changes in detail -->

## Motivation and Context

The goal is to make it easier to track/figure out the deployed version.

## How Has This Been Tested

- [x] Manual testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1202
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- during build add a build version to the container
- endpoint added for requesting build version
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-factory/pull/7

For easier comparison:
https://github.com/UserOfficeProject/user-office-factory/compare/SWAP-1201_CI_CD_Improvements...SWAP-1202_Keep_track_of_the_deployed_versions

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
