### PR TITLE
SWAP-1331 Make proposal PDF more compact

### DIFF
--- a/src/__tests__/api/pdf/proposal-pdf.spec.ts
+++ b/src/__tests__/api/pdf/proposal-pdf.spec.ts
@@ -47,19 +47,19 @@ describe('Proposal PDF', () => {
           expect(text).toMatch(/Questionary 1/);
           expect(text).toMatch(/Visible EMBELLISHMENT/);
           expect(text).not.toMatch(/Hidden EMBELLISHMENT/);
-          expect(text).toMatch(/Date question\n2020-10-27/);
-          expect(text).toMatch(/Boolean question - true\nYes/);
-          expect(text).toMatch(/Boolean question - false\nNo/);
-          expect(text).toMatch(/Selection from options\nSelected answer/);
+          expect(text).toMatch(/Date question 2020-10-27/);
+          expect(text).toMatch(/Boolean question - true Yes/);
+          expect(text).toMatch(/Boolean question - false No/);
+          expect(text).toMatch(/Selection from options Selected answer/);
           expect(text).toMatch(
-            /Selection from options with multiple select\nfoo, bar/
+            /Selection from options with multiple select foo, bar/
           );
           expect(text).toMatch(
             /Interval question\nMin: -1\nMax: 99\nUnit: foo/
           );
           expect(text).toMatch(/Random question\nRandom answer/);
           expect(text).toMatch(/Rich text input question\nrich\ntext\ninput/);
-          expect(text).toMatch(/Number input question\n2345 foo\/bar/);
+          expect(text).toMatch(/Number input question 2345 foo\/bar/);
 
           expect(text).toMatch(/Status\nOkey/);
           expect(text).toMatch(/Time Allocation\n30 Days/);
@@ -81,7 +81,7 @@ describe('Proposal PDF', () => {
           expect(text).toMatch(/Sample 999 - See appendix/);
 
           expect(text).toMatch(/Sample: Foo sample/);
-          expect(text).toMatch(/Sample date question\n2020-10-27/);
+          expect(text).toMatch(/Sample date question 2020-10-27/);
           expect(text).toMatch(/Status:\nNot evaluated/);
           expect(text).toMatch(/Comment:\nSafety foo bar/);
 

--- a/src/__tests__/api/pdf/sample-pdf.spec.ts
+++ b/src/__tests__/api/pdf/sample-pdf.spec.ts
@@ -36,8 +36,8 @@ describe('Sample PDF', () => {
           const text = extractPDFText(pdfPath);
 
           expect(text).toMatch(/Sample: Foo sample/);
-
-          expect(text).toMatch(/Date question\n2020-10-27/);
+          expect(text).toMatch(/Sample basis question\nFoo sample/);
+          expect(text).toMatch(/Date question 2020-10-27/);
 
           expect(text).toMatch(/Status:\nNot evaluated/);
           expect(text).toMatch(/Comment:/);

--- a/src/__tests__/fixtures/pdf-payloads.json
+++ b/src/__tests__/fixtures/pdf-payloads.json
@@ -219,6 +219,13 @@
       "sampleQuestionaryFields": [
         {
           "question": {
+            "dataType": "SAMPLE_BASIS",
+            "question": "Sample basis question"
+          },
+          "value": null
+        },
+        {
+          "question": {
             "dataType": "DATE",
             "question": "Date question"
           },

--- a/src/pdf/index.ts
+++ b/src/pdf/index.ts
@@ -34,7 +34,10 @@ puppeteer
     logger.logException('Failed to start browser puppeteer', e);
   });
 
-export async function generatePdfFromHtml(html: string) {
+export async function generatePdfFromHtml(
+  html: string,
+  { pdfOptions }: { pdfOptions?: puppeteer.PDFOptions } = {}
+) {
   const name = generateTmpPath();
 
   if (process.env.PDF_DEBUG_HTML === '1') {
@@ -53,6 +56,7 @@ export async function generatePdfFromHtml(html: string) {
   await page.pdf({
     path: pdfPath,
     margin: { top: 0, left: 0, bottom: 0, right: 0 },
+    ...pdfOptions,
   });
 
   await page.close();

--- a/src/template/helpers/common.ts
+++ b/src/template/helpers/common.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'fs';
+import { join, extname } from 'path';
+
 import handlebar from 'handlebars';
 
 handlebar.registerHelper('$eq', function(a, b) {
@@ -16,4 +19,22 @@ handlebar.registerHelper('$join', function(src, delimiter) {
   }
 
   return src.join(delimiter);
+});
+
+const extensionMimeTypeMp = new Map<string, string>([['.png', 'image/png']]);
+const base64Cache = new Map<string, Buffer>();
+
+handlebar.registerHelper('$readAsBase64', function(path: string) {
+  path = join(process.cwd(), path);
+
+  let contentBuff = base64Cache.get(path);
+
+  if (contentBuff === undefined) {
+    contentBuff = readFileSync(path);
+    base64Cache.set(path, contentBuff);
+  }
+
+  const mimeType = extensionMimeTypeMp.get(extname(path)) ?? 'unknown';
+
+  return `data:${mimeType};base64,${contentBuff.toString('base64')}`;
 });

--- a/src/template/index.ts
+++ b/src/template/index.ts
@@ -2,6 +2,7 @@ import { promises } from 'fs';
 import { join } from 'path';
 
 import handlebar from 'handlebars';
+import { PDFOptions } from 'puppeteer';
 
 // register helpers
 import './helpers';
@@ -14,12 +15,14 @@ type TemplateNames =
   | 'technical-review.hbs'
   | 'sample.hbs';
 
+const templatesFolder = join(__dirname, '..', '..', 'templates');
+
 export async function renderTemplate(
   templateName: TemplateNames,
   payload: any
 ) {
   const htmlTemplate = await promises.readFile(
-    join(__dirname, '..', '..', 'templates', templateName),
+    join(templatesFolder, templateName),
     'utf-8'
   );
 
@@ -27,4 +30,29 @@ export async function renderTemplate(
   const template = handlebar.compile(htmlTemplate);
 
   return template(payload);
+}
+
+export async function renderHeaderFooter() {
+  const htmlHeaderTemplate = await promises.readFile(
+    join(templatesFolder, 'pdf', 'header.hbs'),
+    'utf-8'
+  );
+
+  const htmlFooterTemplate = await promises.readFile(
+    join(templatesFolder, 'pdf', 'footer.hbs'),
+    'utf-8'
+  );
+
+  const settings: PDFOptions = JSON.parse(
+    await promises.readFile(
+      join(templatesFolder, 'pdf', 'settings.json'),
+      'utf-8'
+    )
+  );
+
+  return {
+    ...settings,
+    headerTemplate: handlebar.compile(htmlHeaderTemplate)(null),
+    footerTemplate: handlebar.compile(htmlFooterTemplate)(null),
+  };
 }

--- a/src/workflows/pdf/proposal.ts
+++ b/src/workflows/pdf/proposal.ts
@@ -182,11 +182,14 @@ class ProposalPdfEmitter extends EventEmitter {
         this.pdfPageGroup.attachments.waitFor = attachmentsFileMeta.length;
 
         this.emit('taskFinished', 'fetch:attachmentsFileMeta');
-        this.emit(
-          'render:questionnaires',
-          questionarySteps,
-          attachmentsFileMeta
-        );
+
+        if (questionarySteps.length > 0) {
+          this.emit(
+            'render:questionnaires',
+            questionarySteps,
+            attachmentsFileMeta
+          );
+        }
 
         if (samples.length > 0) {
           this.emit('render:samples', samples, attachmentsFileMeta);
@@ -231,7 +234,9 @@ class ProposalPdfEmitter extends EventEmitter {
       this.meta.attachments = attachments;
       this.emit('fetch:attachmentsFileMeta', attachments);
     } else {
-      this.emit('render:questionnaires', questionarySteps, []);
+      if (questionarySteps.length > 0) {
+        this.emit('render:questionnaires', questionarySteps, []);
+      }
 
       if (samples.length > 0) {
         this.emit('render:samples', samples, []);

--- a/src/workflows/pdf/sample.ts
+++ b/src/workflows/pdf/sample.ts
@@ -15,7 +15,7 @@ import {
   generatePuppeteerPdfFooter,
 } from '../../pdf';
 import services from '../../services';
-import { renderTemplate } from '../../template';
+import { renderTemplate, renderHeaderFooter } from '../../template';
 import { Answer, Sample, SamplePDFData, Attachment } from '../../types';
 import { failSafeDeleteFiles, generateTmpPath } from '../../util/fileSystem';
 
@@ -174,7 +174,11 @@ class SamplePdfEmitter extends EventEmitter {
         sampleQuestionaryFields,
         attachmentsFileMeta,
       });
-      const pdfPath = await generatePdfFromHtml(renderedSampleHtml);
+      const renderedHeaderFooter = await renderHeaderFooter();
+
+      const pdfPath = await generatePdfFromHtml(renderedSampleHtml, {
+        pdfOptions: renderedHeaderFooter,
+      });
 
       this.emit('countPages', pdfPath, 'sample');
       this.emit('rendered:sample', pdfPath);

--- a/templates/css/default.css
+++ b/templates/css/default.css
@@ -22,20 +22,15 @@ body {
   font-family: 'Calibri';
 }
 
-.logo {
-  margin: 15px;
-  width: 130px;
-}
-
-.root {
-  padding: 0 72px;
-}
-
 .title {
-  font-size: 1rem;
+  font-size: 1.125rem;
   font-weight: bold;
 }
 
 .bold {
   font-weight: bold;
+}
+
+.avoid-page-break-inside {
+  page-break-inside: avoid;
 }

--- a/templates/partials/layout.hbs
+++ b/templates/partials/layout.hbs
@@ -13,8 +13,6 @@
 
 <body>
 
-  <img src="http://localhost:4500/static/images/ESS.png" class="logo" />
-
   <div class="root">
 
     {{> @partial-block }}

--- a/templates/partials/questionaryAnswer.hbs
+++ b/templates/partials/questionaryAnswer.hbs
@@ -1,26 +1,26 @@
-<div class="mb-2">
+<div class="mb-2 avoid-page-break-inside">
   {{#if ($eq this.step.question.dataType 'EMBELLISHMENT') }}
     {{#unless this.step.config.omitFromPdf }}
-      <span class="bold">{{this.step.config.plain}}</span><br />
+      <div class="bold">{{this.step.config.plain}}</div>
     {{/unless}}
   {{else if ($eq this.step.question.dataType 'FILE_UPLOAD') }}
-    <span class="bold">{{this.step.question.question}}</span><br />
+    <div class="bold">{{this.step.question.question}}</div>
     {{#if this.step.value}}
       {{{ $attachment this.step.value this.attachmentsFileMeta }}}
     {{else}}
-      Left blank
+      <em>Left blank</em>
     {{/if}}
     <br />
   {{else if ($eq this.step.question.dataType 'DATE') }}
-    <span class="bold">{{this.step.question.question}}</span><br />
+    <span class="bold">{{this.step.question.question}}</span>
     {{#if this.step.value}}
       {{ $utcDate this.step.value}}
     {{else}}
-      Left blank
+      <em>Left blank</em>
     {{/if}}
     <br />
   {{else if ($eq this.step.question.dataType 'BOOLEAN')}}
-    <span class="bold">{{this.step.question.question}}</span><br />
+    <span class="bold">{{this.step.question.question}}</span>
     {{#if this.step.value}}
       Yes
     {{else}}
@@ -28,7 +28,7 @@
     {{/if}}
     <br />
   {{else if ($eq this.step.question.dataType 'SAMPLE_DECLARATION')}}
-    <span class="bold">{{this.step.question.question}}</span><br />
+    <div class="bold">{{this.step.question.question}}</div>
     <br />
 
     <div class="ml-3">
@@ -38,42 +38,63 @@
         <br /><br />
       {{/each}}
       {{#unless this.step.value}}
-        <div class="mb-2">Left blank</div>
+        <div class="mb-2"><em>Left blank</em></div>
       {{/unless}}
     </div>
 
   {{else if ($eq this.step.question.dataType 'INTERVAL')}}
-    <span class="bold">{{this.step.question.question}}</span><br />
+    <div class="bold">{{this.step.question.question}}</div>
     {{#if this.value}}
       Min: {{this.step.value.min}}<br />
       Max: {{this.step.value.max}}<br />
       Unit: {{this.step.value.unit}}
     {{else}}
-      Left blank
+      <em>Left blank</em>
     {{/if}}
 
   {{else if ($eq this.step.question.dataType 'NUMBER_INPUT')}}
-    <span class="bold">{{this.step.question.question}}</span><br />
+    <span class="bold">{{this.step.question.question}}</span>
     {{#if this.step.value}}
       {{this.step.value.value}} {{this.step.value.unit}}
     {{else}}
-      Left blank
+      <em>Left blank</em>
     {{/if}}
 
   {{else if ($eq this.step.question.dataType 'RICH_TEXT_INPUT')}}
-    <span class="bold">{{this.step.question.question}}</span><br />
+    <div class="bold">{{this.step.question.question}}</div>
     {{#if this.step.value}}
       {{{this.step.value}}}
     {{else}}
-      Left blank
+      <em>Left blank</em>
     {{/if}}
 
-  {{else}}
-    <span class="bold">{{this.step.question.question}}</span><br />
+  {{else if ($eq this.step.question.dataType 'SELECTION_FROM_OPTIONS')}}
+    <span class="bold">{{this.step.question.question}}</span>
     {{#if this.step.value}}
       {{$join this.value ', '}}
     {{else}}
-      Left blank
+      <em>Left blank</em>
+    {{/if}}
+
+  {{else if ($eq this.step.question.dataType 'SAMPLE_BASIS')}}
+    <div class="bold">{{this.step.question.question}}</div>
+    {{! 
+        SAMPLE_BASIS is a special case, its value is never set
+        instead we have to use the sample title title directly
+        as that is what actually holds the relevant value
+    }}
+    {{#if this.sample.title}}
+      {{ this.sample.title }}
+    {{else}}
+      <em>Left blank</em>
+    {{/if}}
+
+  {{else}}
+    <div class="bold">{{this.step.question.question}}</div>
+    {{#if this.step.value}}
+      {{$join this.value ', '}}
+    {{else}}
+      <em>Left blank</em>
     {{/if}}
   {{/if}}
 

--- a/templates/pdf/footer.hbs
+++ b/templates/pdf/footer.hbs
@@ -1,0 +1,2 @@
+{{!-- Needed to avoid default footer --}}
+<span></span>

--- a/templates/pdf/header.hbs
+++ b/templates/pdf/header.hbs
@@ -1,0 +1,8 @@
+<style>
+  .logo {
+    width: 100px;
+    margin: -10px 0 0 5px;
+    padding: 0;
+  }
+</style>
+<img src="{{{ $readAsBase64 './templates/images/ESS.png' }}}" class="logo" />

--- a/templates/pdf/settings.json
+++ b/templates/pdf/settings.json
@@ -1,0 +1,9 @@
+{
+  "margin": {
+    "top": 82,
+    "left": 72,
+    "bottom": 72,
+    "right": 72
+  },
+  "displayHeaderFooter": true
+}

--- a/templates/questionary-step.hbs
+++ b/templates/questionary-step.hbs
@@ -1,17 +1,19 @@
 {{#> layout}}
 
   <div class="container-fluid">
-    <div class="row">
-      <div class="col">
-        <span class="title">{{step.topic.title}}</span><br />
-        <br />
+    {{#each steps}}
+      <div class="row">
+        <div class="col">
+          <div class="title mb-1">{{this.topic.title}}</div>
 
-        {{#each step.fields}}
-          {{> questionaryAnswer step=this attachmentsFileMeta=../attachmentsFileMeta}}
-        {{/each}}
+          {{#each this.fields}}
+            {{> questionaryAnswer step=this attachmentsFileMeta=../../attachmentsFileMeta}}
+          {{/each}}
 
+          <div class="mb-3"></div>
+        </div>
       </div>
-    </div>
+    {{/each}}
   </div>
 
 {{/layout}}

--- a/templates/sample.hbs
+++ b/templates/sample.hbs
@@ -8,7 +8,7 @@
         <br />
 
         {{#each sampleQuestionaryFields}}
-          {{> questionaryAnswer step=this attachmentsFileMeta=../attachmentsFileMeta}}
+          {{> questionaryAnswer step=this attachmentsFileMeta=../attachmentsFileMeta sample=../sample}}
         {{/each}}
         <br />
 


### PR DESCRIPTION
## Description

This PR merges the topics (questionaries) rendering in one step and also removes some line breaks in case of simple questions.
<!--- Describe your changes in detail -->

## Motivation and Context

Currently, we may have too much empty space between topics.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] unit test
- [x] manual test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1331
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- proposal topics merged, rendered in one step
- added option to set header and footer using templates
- logo removed from the template instead we use pdf header
- questionary rendering updated (removed line breaks and added explicit rendering logic to some questionnaires)
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
