### PR TITLE
Interval question on the same line

### DIFF
--- a/src/__tests__/api/pdf/proposal-pdf.spec.ts
+++ b/src/__tests__/api/pdf/proposal-pdf.spec.ts
@@ -54,11 +54,9 @@ describe('Proposal PDF', () => {
           expect(text).toMatch(
             /Selection from options with multiple select foo, bar/
           );
-          expect(text).toMatch(
-            /Interval question\nMin: -1\nMax: 99\nUnit: foo/
-          );
-          expect(text).toMatch(/Interval question - no answer\nLeft blank/);
-          expect(text).toMatch(/Interval question - no unit\nMin: 1\nMax: 2/);
+          expect(text).toMatch(/Interval question -1 - 99 foo/);
+          expect(text).toMatch(/Interval question - no answer Left blank/);
+          expect(text).toMatch(/Interval question - no unit 1 - 2/);
           expect(text).toMatch(/Random question\nRandom answer/);
           expect(text).toMatch(/Rich text input question\nrich\ntext\ninput/);
           expect(text).toMatch(/Number input question 2345 foo\/bar/);

--- a/templates/partials/questionaryAnswer.hbs
+++ b/templates/partials/questionaryAnswer.hbs
@@ -43,7 +43,7 @@
     </div>
 
   {{else if ($eq this.step.question.dataType 'INTERVAL')}}
-    <div class="bold">{{this.step.question.question}}</div>
+    <span class="bold">{{this.step.question.question}}</span>
     {{#if ($or this.step.value.min this.step.value.max) }}
     {{this.step.value.min}} - {{this.step.value.max}} 
       {{#if this.step.value.unit }}

--- a/templates/partials/questionaryAnswer.hbs
+++ b/templates/partials/questionaryAnswer.hbs
@@ -45,10 +45,9 @@
   {{else if ($eq this.step.question.dataType 'INTERVAL')}}
     <div class="bold">{{this.step.question.question}}</div>
     {{#if ($or this.step.value.min this.step.value.max) }}
-      Min: {{this.step.value.min}}<br />
-      Max: {{this.step.value.max}}<br />
+    {{this.step.value.min}} - {{this.step.value.max}} 
       {{#if this.step.value.unit }}
-        Unit: {{this.step.value.unit}}
+        {{this.step.value.unit}}
       {{/if}}
     {{else}}
       <em>Left blank</em>


### PR DESCRIPTION
## Description

A interval question now renders as:
"question text"
Min: x
Max: y
Unit: z

It could instead be rendered like in the review panel as:

"question text" x-y z


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
