### PR TITLE
Add env var for setting a DB connection string

### DIFF
--- a/src/dataSources/postgres/database.ts
+++ b/src/dataSources/postgres/database.ts
@@ -3,14 +3,16 @@ import Knex from 'knex';
 
 const db = Knex({
   client: 'postgresql',
-  connection: {
-    host: process.env.DATABASE_HOSTNAME,
-    port: +(process.env.DATABASE_PORT as string) || 5432,
-    user: process.env.DATABASE_USER,
-    password: process.env.DATABASE_PASSWORD,
-    database: process.env.DATABASE_DATABASE,
-    timezone: 'UTC',
-  },
+  connection: process.env.DATABASE_CONNECTION_STRING
+    ? process.env.DATABASE_CONNECTION_STRING
+    : {
+        host: process.env.DATABASE_HOSTNAME,
+        port: +(process.env.DATABASE_PORT as string) || 5432,
+        user: process.env.DATABASE_USER,
+        password: process.env.DATABASE_PASSWORD,
+        database: process.env.DATABASE_DATABASE,
+        timezone: 'UTC',
+      },
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Part of UserOfficeProject/stfc-user-office-project#206

## Description
The factory will now check if an environment variable called `DATABASE_CONNECTION_STRING` is present when setting up the DB connection. If so, it will use it to set all DB connection properties rather than the other single-property env vars.

## Motivation and Context
This allows the factory's DB connection to be configured with the same connection string as the backend, making it easy to apply changes to both apps automatically. It also allows us to configure extra properties which aren't corrently read from env vars, such as SSL settings.

## How Has This Been Tested
Manually by triggering the service from the frontend.

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
