### PR TITLE
feat: support generic templates in proposal PDF

### DIFF
--- a/src/__tests__/api/pdf/proposal-pdf.spec.ts
+++ b/src/__tests__/api/pdf/proposal-pdf.spec.ts
@@ -63,6 +63,13 @@ describe('Proposal PDF', () => {
           expect(text).toMatch(/Number input question - no answer Left blank/);
           expect(text).toMatch(/Number input question - no unit 2345/);
 
+          expect(text).toMatch(/Generic template main question/);
+          expect(text).toMatch(/1 of 1/);
+          expect(text).toMatch(/Generic template basis question/);
+          expect(text).toMatch(/Generic template basis answer/);
+          expect(text).toMatch(/Text question/);
+          expect(text).toMatch(/Text answer/);
+
           expect(text).toMatch(/Status\nOkey/);
           expect(text).toMatch(/Time Allocation\n30 Days/);
           expect(text).toMatch(/Comment\nTechnical review lorem ipsum/);

--- a/src/__tests__/fixtures/pdf-payloads.json
+++ b/src/__tests__/fixtures/pdf-payloads.json
@@ -146,6 +146,44 @@
                 "question": "Random question"
               },
               "value": "Random answer"
+            },
+            {
+              "question":{
+                "id":"generic_template_1234",
+                "dataType":"GENERIC_TEMPLATE",
+                "question":"Generic template main question"
+              },
+              "value":[
+                {
+                  "title":"Generic template answer #1",
+                  "questionId":"generic_template_1234"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "genericTemplates":[
+        {
+          "genericTemplate":{
+            "title":"Generic template basis answer",
+            "questionId":"generic_template_1234"
+          },
+          "genericTemplateQuestionaryFields":[
+            {
+              "question":{
+                "dataType":"GENERIC_TEMPLATE_BASIS"
+              },
+              "config":{
+                "questionLabel":"Generic template basis question"
+              }
+            },
+            {
+              "question":{
+                "dataType":"TEXT_INPUT",
+                "question":"Text question"
+              },
+              "value":"Text answer"
             }
           ]
         }
@@ -233,7 +271,8 @@
             }
           ]
         }
-      ]
+      ],
+      "genericTemplates": []
     }
   ],
   "sample_test_1": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type ProposalPDFData = {
   coProposers: BasicUser[];
   attachments: Attachment[];
   samples: ProposalSampleData[];
+  genericTemplates: GenericTemplate[];
   technicalReview?: {
     status: string;
     timeAllocation: number;
@@ -153,4 +154,13 @@ export class Shipment {
 export enum ShipmentStatus {
   DRAFT = 'DRAFT',
   SUBMITTED = 'SUBMITTED',
+}
+
+export interface GenericTemplate {
+  id: number;
+  title: string;
+  creatorId: number;
+  questionaryId: number;
+  questionId: string;
+  created: Date;
 }

--- a/src/workflows/pdf/proposal.ts
+++ b/src/workflows/pdf/proposal.ts
@@ -10,6 +10,7 @@ import {
   ProposalPDFData,
   ProposalSampleData,
   Attachment,
+  GenericTemplate,
 } from '../../types';
 import PdfFactory, { PdfFactoryCountedPagesMeta } from './PdfFactory';
 import PdfWorkflowManager from './PdfWorkflowManager';
@@ -19,6 +20,7 @@ type ProposalPDFMeta = {
     proposal: string;
     questionnaires: string[];
     samples: string[];
+    genericTemplates: string[];
     attachments: string[];
     technicalReview: string;
   };
@@ -38,6 +40,7 @@ export class ProposalPdfFactory extends PdfFactory<
       proposal: '',
       questionnaires: [],
       samples: [],
+      genericTemplates: [],
       attachments: [],
       technicalReview: '',
     },
@@ -56,6 +59,7 @@ export class ProposalPdfFactory extends PdfFactory<
       technicalReview,
       attachments,
       samples,
+      genericTemplates,
     } = data;
 
     this.countedPagesMeta = {
@@ -69,6 +73,10 @@ export class ProposalPdfFactory extends PdfFactory<
         countedPagesPerPdf: {},
       },
       samples: { waitFor: samples.length, countedPagesPerPdf: {} },
+      genericTemplates: {
+        waitFor: genericTemplates.length,
+        countedPagesPerPdf: {},
+      },
       attachments: {
         waitFor: 0 /* set by fetched:attachmentsFileMeta */,
         countedPagesPerPdf: {},
@@ -169,6 +177,7 @@ export class ProposalPdfFactory extends PdfFactory<
           this.emit(
             'render:questionnaires',
             questionarySteps,
+            genericTemplates,
             attachmentsFileMeta
           );
         }
@@ -211,7 +220,12 @@ export class ProposalPdfFactory extends PdfFactory<
       this.emit('fetch:attachmentsFileMeta', attachments);
     } else {
       if (questionarySteps.length > 0) {
-        this.emit('render:questionnaires', questionarySteps, []);
+        this.emit(
+          'render:questionnaires',
+          questionarySteps,
+          genericTemplates,
+          []
+        );
       }
 
       if (samples.length > 0) {
@@ -252,6 +266,7 @@ export class ProposalPdfFactory extends PdfFactory<
 
   private async renderQuestionarySteps(
     questionarySteps: QuestionaryStep[],
+    genericTemplates: GenericTemplate[],
     attachmentsFileMeta: FileMetadata[]
   ) {
     if (this.stopped) {
@@ -263,7 +278,7 @@ export class ProposalPdfFactory extends PdfFactory<
     try {
       const renderedProposalQuestion = await renderTemplate(
         'questionary-step.hbs',
-        { steps: questionarySteps, attachmentsFileMeta }
+        { steps: questionarySteps, genericTemplates, attachmentsFileMeta }
       );
       const renderedHeaderFooter = await renderHeaderFooter();
 

--- a/templates/partials/genericTemplates.hbs
+++ b/templates/partials/genericTemplates.hbs
@@ -1,0 +1,49 @@
+{{#> layout}}
+
+  <div class="mb-3">
+
+    <span class="bold">{{question.question}}</span><br />
+    <br />
+
+    {{#unless this.templates.length}}
+      Left blank
+    {{/unless}}
+
+    <div class="row">
+
+      {{#each this.templates}}
+        {{#if ($eq this.genericTemplate.questionId ../question.id) }}
+
+          <div class="col-6 border avoid-page-break-inside">
+
+            <div class="mb-2 mt-2">
+              <em>{{ $sum @index 1 }} of {{ ../this.templates.length }}</em>
+            </div>
+
+            {{#each this.genericTemplateQuestionaryFields}}
+              {{!
+                  GENERIC_TEMPLATE_BASIS has its question and answer stored
+                  differently to the other generic template questions, so it
+                  is rendered in this partial. All other questions are passed
+                  back to questionaryAnswer to be rendered as normal questions.
+              }}
+              {{#if ($eq this.question.dataType 'GENERIC_TEMPLATE_BASIS') }}
+                <div class="mb-2 avoid-page-break-inside">
+                  <span class="bold">{{ this.config.questionLabel }}</span><br />
+                  {{ ../this.genericTemplate.title }}
+                </div>
+              {{else}}
+                {{> questionaryAnswer step=this genericTemplates=../../genericTemplates attachmentsFileMeta=../../attachmentsFileMeta }}
+              {{/if}}
+            {{/each}}
+
+          </div>
+
+        {{/if}}
+      {{/each}}
+
+    </div>
+
+  </div>
+
+{{/layout}}

--- a/templates/partials/questionaryAnswer.hbs
+++ b/templates/partials/questionaryAnswer.hbs
@@ -1,4 +1,7 @@
-<div class="mb-2 avoid-page-break-inside">
+{{#unless ($eq this.step.question.dataType 'GENERIC_TEMPLATE') }}
+  <div class="mb-2 avoid-page-break-inside">
+{{/unless}}
+
   {{#if ($eq this.step.question.dataType 'EMBELLISHMENT') }}
     {{#unless this.step.config.omitFromPdf }}
       <div class="bold">{{this.step.config.plain}}</div>
@@ -79,7 +82,7 @@
 
   {{else if ($eq this.step.question.dataType 'SAMPLE_BASIS')}}
     <div class="bold">{{this.step.question.question}}</div>
-    {{! 
+    {{!
         SAMPLE_BASIS is a special case, its value is never set
         instead we have to use the sample title title directly
         as that is what actually holds the relevant value
@@ -89,7 +92,14 @@
     {{else}}
       <em>Left blank</em>
     {{/if}}
-
+  {{else if ($eq this.step.question.dataType 'GENERIC_TEMPLATE')}}
+    {{!
+        GENERIC_TEMPLATE question type contains sub questions. The
+        genericTemplates partial is used to loop through these and
+        provide additional formatting, and each (sub) question is
+        then passed back to this partial for rendering.
+    }}
+    {{> genericTemplates question=this.step.question templates=genericTemplates attachmentsFileMeta=this.attachmentsFileMeta }}
   {{else}}
     <div class="bold">{{this.step.question.question}}</div>
     {{#if this.step.value}}
@@ -99,4 +109,7 @@
     {{/if}}
   {{/if}}
 
-</div>
+{{#unless ($eq this.step.question.dataType 'GENERIC_TEMPLATE') }}
+  </div>
+
+{{/unless}}

--- a/templates/questionary-step.hbs
+++ b/templates/questionary-step.hbs
@@ -7,7 +7,7 @@
           <div class="title mb-1">{{this.topic.title}}</div>
 
           {{#each this.fields}}
-            {{> questionaryAnswer step=this attachmentsFileMeta=../../attachmentsFileMeta}}
+            {{> questionaryAnswer step=this genericTemplates=../../genericTemplates attachmentsFileMeta=../../attachmentsFileMeta}}
           {{/each}}
 
           <div class="mb-3"></div>


### PR DESCRIPTION
## Description

This adds support for `GENERIC_TEMPLATE` question type in proposal PDFs. These question types can contain sub-questions.

We decided to make these generic templates display in grid format to save space. For now this is 2 columns wide but can be changed in the future. Further down the line, we may also want to include an option on whether to display these questions in grid format (similar to "omit from pdf") .

## Motivation and Context

Generic template questions don't display at all currently

## Screenshots
<img src="https://user-images.githubusercontent.com/14293717/141497575-3e3d5013-b3ef-43b9-9a78-8648d006e3ea.png" alt="Your image title" width="250"/>
<img src="https://user-images.githubusercontent.com/14293717/141495555-e0e849b0-2e68-4d61-9950-05ff91094a1c.png" alt="Your image title" width="250"/>
<img src="https://user-images.githubusercontent.com/14293717/141495511-52b24465-961d-4b89-b048-2973473fb4b2.png" alt="Your image title" width="250"/>

## Known issue
The boxes don't split properly onto separate pages (see screenshot).

I think this is because the CSS rule `page-break-inside: avoid;` isn't being respected. I tried various things with Bootstrap columns and rows, and also overriding that by using flex. The only way I could get it to work was with a single column, not multiple. It seems to be an older CSS rule and the only possible solution I could find was to put the layout in a table. I guess this would be fine since it's all rendered to PDF anyway, but I think it would require additional logic of when to insert new rows, which I wasn't sure was the right route.

<img src="https://user-images.githubusercontent.com/14293717/141495713-834d0022-ff83-408d-8dc3-3f4cb11a8401.png" alt="Your image title" width="250"/>

## How Has This Been Tested

Pretty much what is shown in the screenshots, please let me know if I should test more than this:

- Proposal PDF with a generic template question but no answer
- Proposal PDF with a generic template question and 1 answer
- Proposal PDF with a generic template question and multiple answers
- Proposal PDF with no generic templates
- Existing test extended to cover generic templates

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Closes UserOfficeProject/stfc-user-office-project#222

## Changes

- New partial created, `genericTemplates.hbs` that handles generic template logic
- `questionaryAnswer.hbs` modified so that when the question type is `GENERIC_TEMPLATE`, the template info is passed to `genericTemplates.hbs`
- `genericTemplates.hbs` gives each question back to `questionaryAnswer.hbs` for rendering, to avoid repeated logic

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
