### PR TITLE
fix: add missing canvas dependencies

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,7 +11,13 @@ RUN apk add --no-cache \
   ttf-freefont \
   nodejs \
   npm \
-  graphicsmagick
+  graphicsmagick \
+  build-base \
+  g++ \
+  cairo-dev \
+  jpeg-dev \
+  pango-dev \
+  giflib-dev
 
 WORKDIR /tmp
 


### PR DESCRIPTION
## Description

Adds dependencies required to build Canvas from source, needed after the pre-built binaries were removed and no longer seem to be supported

See https://github.com/Automattic/node-canvas/issues/1962 for more info.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Fixes #74

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
