### PR TITLE
Swap 2039 Add STFC compatibility to Node upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
   PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Add user so we don't need --no-sandbox.
-RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+RUN addgroup -S -g 1000 pptruser && adduser -S -u 1000 -g pptruser pptruser \
   && mkdir -p /home/pptruser/Downloads /app \
   && chown -R pptruser:pptruser /home/pptruser \
   && chown -R pptruser:pptruser /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,13 +17,17 @@ RUN apk add --no-cache \
   cairo-dev \
   jpeg-dev \
   pango-dev \
-  giflib-dev
-
-WORKDIR /tmp
+  giflib-dev \
+  && addgroup -S -g 1000 pptruser && adduser -S -u 1000 -g pptruser pptruser \
+  && mkdir -p /home/pptruser/Downloads /app \
+  && chown -R pptruser:pptruser /home/pptruser \
+  && chown -R pptruser:pptruser /app
 
 #Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
   PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+USER pptruser
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "user-office-factory",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "user-office-factory",
   "version": "1.0.0",
   "description": "",
   "main": "build/index.js",


### PR DESCRIPTION
## Description
Tweaks the dev Dockerfile and `package.json` to avoid problems in the STFC setup.

## Motivation and Context
This lets the app remain compatible with the STFC setup after the Node upgrade.

## How Has This Been Tested
Locally on my machine, checking if the dev container starts up and generates correct PDFs.

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
