### PR TITLE
Push the image to the GitHub Container Registry

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -47,7 +47,9 @@ jobs:
         with:
           build-args: BUILD_VERSION=${{ github.sha }}
           push: true
-          tags: dmsc/duo-factory:${{ steps.extract_branch.outputs.branch }}
+          tags: |
+            dmsc/duo-factory:${{ steps.extract_branch.outputs.branch }}
+            ghcr.io/userofficeproject/user-office-factory:${{ steps.extract_branch.outputs.branch }}
 
       - name: Trigger pipeline
         run: |

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -26,6 +26,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+          
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract branch name
         id: extract_branch


### PR DESCRIPTION

## Description

This PR aims to add changes to the GitHub workflow to include the push of the docker image to the new GitHub Container Registry.

After this is merged, the image is still pushed to the old location for backward compatibility reasons

## Motivation and Context

There are two reasons for moving away from docker io
  - We run our pipelines on GitHub so it will be faster to download and will have better support for the future
  - ghcr seems to have better support for container registry service

## Fixes
https://jira.esss.lu.se/browse/SWAP-2809

## Changes

Workflow files
