### PR TITLE
Chore: Remove pushing to dockerhub

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -45,9 +39,7 @@ jobs:
         with:
           build-args: BUILD_VERSION=${{ github.sha }}
           push: true
-          tags: |
-            dmsc/duo-factory:${{ steps.extract_branch.outputs.branch }}
-            ghcr.io/userofficeproject/user-office-factory:${{ steps.extract_branch.outputs.branch }}
+          tags: ghcr.io/userofficeproject/user-office-factory:${{ steps.extract_branch.outputs.branch }}
 
       - name: Trigger pipeline
         uses: swapActions/trigger-useroffice-deployment@v1

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -25,11 +25,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
         # Build and push release image tagged with the same tag as github release
       - name: Build and push
@@ -38,4 +39,4 @@ jobs:
         with:
           build-args: BUILD_VERSION=${{ github.sha }}
           push: true
-          tags: dmsc/duo-factory:${{ steps.tag_version.outputs.new_tag }}
+          tags: ghcr.io/userofficeproject/user-office-factory:${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -60,11 +60,12 @@ jobs:
             ${{ runner.os }}-buildx-${{ github.head_ref }}-
             ${{ runner.os }}-buildx-
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # For debugging capture the selected branch
       - name: Extracted branch
@@ -74,6 +75,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: dmsc/duo-factory:${{ github.head_ref }}
+          tags: ghcr.io/userofficeproject/user-office-factory:${{ github.head_ref }}
           cache-from: type=local,src=/tmp/.buildx-layer-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-layer-cache

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.1"
 
 services:
   factory:
-    image: dmsc/duo-factory:${USER_OFFICE_FACTORY_TAG}
+    image: ghcr.io/userofficeproject/user-office-factory:${USER_OFFICE_FACTORY_TAG}
     environment:
       NODE_ENV: development
       DATABASE_HOSTNAME: localhost

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -2,7 +2,7 @@ version: "3.1"
 
 services:
   factory:
-    image: dmsc/duo-factory:${USER_OFFICE_FACTORY_TAG}
+    image: ghcr.io/userofficeproject/user-office--factory:${USER_OFFICE_FACTORY_TAG}
     environment:
       NODE_ENV: production
       DATABASE_HOSTNAME: localhost


### PR DESCRIPTION
Ref: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/842

## Description

Push the docker image to GitHub docker registry instead of dockerhub

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
