### PR TITLE
chore: avoid pushing and logging in to github if dependabot creates the image

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -61,6 +61,8 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to GitHub Container Registry
+        # Don't login if dependabot is creating the PR
+        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -74,7 +76,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          push: true
+          # Don't push if dependabot is creating the PR
+          push: ${{ !startsWith(github.head_ref, 'dependabot') }}
           tags: ghcr.io/userofficeproject/user-office-factory:${{ github.head_ref }}
           cache-from: type=local,src=/tmp/.buildx-layer-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-layer-cache


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Avoid pushing and logging in to github if dependabot creates the PR

## Motivation and Context

Dependabot doesn't have access to the repository secrets and can't login to dockerhub for a push. That's not needed on a PR created by dependabot.
