### PR TITLE
fix: bringing in the flag --exit-child, which ensures killing the process during heavy operation. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:watch": "jest --watchAll --runInBand --detectOpenHandles",
     "build": "rm -rf ./build && tsc",
     "prod": "npm run build && env NODE_ENV=production node ./build/index.js",
-    "dev": "ts-node-dev --rs --trace-warnings --respawn ./src/index.ts",
+    "dev": "ts-node-dev --rs --trace-warnings --respawn --exit-child ./src/index.ts",
     "dev:docker": "npm install && ts-node-dev --inspect=0.0.0.0:9229 --rs --respawn ./src/index.ts",
     "debug": "ts-node-dev --rs --trace-warnings --inspect --respawn ./src/index.ts",
     "lint": "tsc --noEmit && eslint ./src --ext .js,.ts --quiet",


### PR DESCRIPTION
## Description

The Pupeetter process was quite heavy that was blocking the ts-node-dev from restarting the server on file changes. This is bcoz, the ts-node-dev was unable to kill the existing process. Hence, bringing in the flag --exit-child, which ensures killing the process during these kind of situations. 

## Motivation and Context

https://github.com/wclr/ts-node-dev/issues/69#issuecomment-493675960

## How Has This Been Tested

Yes

## Fixes

Yes

## Changes

script level changes. 

## Tests included/Docs Updated?

No