### PR TITLE
fix: Pass proposal parameter to the render questionary function.

### DIFF
--- a/src/workflows/pdf/proposal/AutoProposalPdfFactory.ts
+++ b/src/workflows/pdf/proposal/AutoProposalPdfFactory.ts
@@ -158,6 +158,7 @@ export class AutoProposalPdfFactory extends PdfFactory<
         if (questionarySteps.length > 0) {
           this.emit(
             'render:questionnaires',
+            proposal,
             questionarySteps,
             genericTemplates,
             attachmentsFileMeta

--- a/src/workflows/pdf/proposal/CustomProposalPdfFactory.ts
+++ b/src/workflows/pdf/proposal/CustomProposalPdfFactory.ts
@@ -50,13 +50,7 @@ export class CustomProposalPdfFactory extends PdfFactory<
   }
 
   init(data: ProposalPDFData) {
-    const {
-      questionarySteps,
-      technicalReview,
-      attachments,
-      samples,
-      genericTemplates,
-    } = data;
+    const { attachments } = data;
 
     const noRenders = {
       waitFor: 0,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

Auto Proposal template was returning PDF, which has blank pages, that are supposed to be the questionarries. 

<!--- Describe your changes in detail -->

Pass the missing proposal parameter to the render:questionaries event. 

<!--- Why is this change required? What problem does it solve? -->

STFC facing the problem with PDF download based on Auto template.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-3413

## Changes

AutoProposalPdfFactory.ts
