### PR TITLE
fix: Add missing role variable to the handlebar.

### DIFF
--- a/src/workflows/pdf/proposal/CustomProposalPdfFactory.ts
+++ b/src/workflows/pdf/proposal/CustomProposalPdfFactory.ts
@@ -128,7 +128,11 @@ export class CustomProposalPdfFactory extends PdfFactory<
         this.countedPagesMeta.attachments.waitFor = attachmentsFileMeta.length;
 
         this.emit('taskFinished', 'fetch:attachmentsFileMeta');
-        this.emit('render:proposal', { ...data, attachmentsFileMeta });
+        this.emit('render:proposal', {
+          ...data,
+          attachmentsFileMeta,
+          userRole: this.userRole,
+        });
 
         if (this.countedPagesMeta.attachments.waitFor === 0) {
           this.emit('taskFinished', 'fetch:attachments');


### PR DESCRIPTION
## Description

Add Missing User Role variable to the Handlebar pdf template. 

## Motivation and Context

Resolve User role not working. 

## How Has This Been Tested

Manually

## Changes

Add new User Role variable