### PR TITLE
fix: use organisation as a template param

### DIFF
--- a/example.custom-proposal-body.hbs
+++ b/example.custom-proposal-body.hbs
@@ -86,8 +86,8 @@
                   <span
                     >{{ principalInvestigator.firstname }} {{
                     principalInvestigator.lastname }}, {{
-                    principalInvestigator.position }}, {{
-                    principalInvestigator.organisation }}</span
+                    principalInvestigator.position }}, {{#if principalInvestigator.organisation}}{{
+                      principalInvestigator.organisation}}{{else}}{{principalInvestigator.institution}}{{/if}}</span
                   >
                 </div>
               </div>
@@ -99,8 +99,7 @@
                 <div class="col-8">
                   {{#each coProposers}}
                   <span
-                    >{{ this.firstname }} {{ this.lastname }}, {{
-                    this.organisation }}</span
+                    >{{ this.firstname }} {{ this.lastname }}, {{#if this.organisation}}{{this.organisation}}{{else}}{{this.institution}}{{/if}}</span
                   >
                   {{/each}}
                 </div>

--- a/src/__tests__/fixtures/pdf-payloads-custom.ts
+++ b/src/__tests__/fixtures/pdf-payloads-custom.ts
@@ -2,10 +2,10 @@ const template = `
 <p>Custom template
 <p>Proposal title: {{ proposal.title }}
 <p>Proposal ID: {{ proposal.proposalId }}
-<p>PI: {{ principalInvestigator.firstname }} {{ principalInvestigator.lastname }} {{ principalInvestigator.organisation }} {{ principalInvestigator.position }}
+<p>PI: {{ principalInvestigator.firstname }} {{ principalInvestigator.lastname }} {{ principalInvestigator.institution }} {{ principalInvestigator.position }}
 <p>CoIs:
 {{#each coProposers}}
-  {{ firstname }} {{ lastname }} ({{organisation}}){{#unless @last}},{{/unless}}
+  {{ firstname }} {{ lastname }} ({{institution}}){{#unless @last}},{{/unless}}
 {{/each}}
 
 <p>Boolean question 1: {{ answers.boolean_1 }}
@@ -77,19 +77,19 @@ export default {
       principalInvestigator: {
         firstname: 'Foo',
         lastname: 'Bar',
-        organisation: 'Baz',
+        institution: 'Baz',
         position: 'Foobar',
       },
       coProposers: [
         {
           firstname: 'Co Foo 1',
           lastname: 'Co Bar 1',
-          organisation: 'Co Baz 1',
+          institution: 'Co Baz 1',
         },
         {
           firstname: 'Co Foo 2',
           lastname: 'Co Bar 2',
-          organisation: 'Co Baz 2',
+          institution: 'Co Baz 2',
         },
       ],
       attachments: [],

--- a/src/__tests__/fixtures/pdf-payloads.json
+++ b/src/__tests__/fixtures/pdf-payloads.json
@@ -16,19 +16,19 @@
       "principalInvestigator": {
         "firstname": "Foo",
         "lastname": "Bar",
-        "organisation": "Baz",
+        "institution": "Baz",
         "position": "Foobar"
       },
       "coProposers": [
         {
           "firstname": "Co Foo 1",
           "lastname": "Co Bar 1",
-          "organisation": "Co Baz 1"
+          "institution": "Co Baz 1"
         },
         {
           "firstname": "Co Foo 2",
           "lastname": "Co Bar 2",
-          "organisation": "Co Baz 2"
+          "institution": "Co Baz 2"
         }
       ],
       "attachments": [],
@@ -254,14 +254,14 @@
       "principalInvestigator": {
         "firstname": "Bar",
         "lastname": "Baz",
-        "organisation": "Foo AB",
+        "institution": "Foo AB",
         "position": "Foo"
       },
       "coProposers": [
         {
           "firstname": "Co Foo",
           "lastname": "Co Bar",
-          "organisation": "Co Baz"
+          "institution": "Co Baz"
         }
       ],
       "attachments": [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export interface BasicUser {
   id: number;
   firstname: string;
   lastname: string;
-  organisation: string;
+  institution: string;
   position: string;
   created: Date;
   placeholder: boolean;

--- a/templates/proposal-main.hbs
+++ b/templates/proposal-main.hbs
@@ -24,7 +24,7 @@
 
         <span class="bold">Co-proposer:</span><br />
         {{#each coProposers}}
-          {{this.firstname}} {{this.lastname}}, {{#if principalInvestigator.organisation}}{{principalInvestigator.organisation}}{{else}}{{principalInvestigator.institution}}{{/if}}<br />
+          {{this.firstname}} {{this.lastname}}, {{#if this.organisation}}{{this.organisation}}{{else}}{{this.institution}}{{/if}}<br />
         {{/each}}
 
       </div>

--- a/templates/proposal-main.hbs
+++ b/templates/proposal-main.hbs
@@ -18,13 +18,13 @@
         <br />
         <span class="bold">Principal Investigator:</span><br />
         {{principalInvestigator.firstname}} {{principalInvestigator.lastname}}<br />
-        {{principalInvestigator.organisation}}<br />
+        {{#if principalInvestigator.organisation}}{{principalInvestigator.organisation}}{{else}}{{principalInvestigator.institution}}{{/if}}<br />
         {{principalInvestigator.position}}<br />
         <br />
 
         <span class="bold">Co-proposer:</span><br />
         {{#each coProposers}}
-          {{this.firstname}} {{this.lastname}}, {{this.organisation}}<br />
+          {{this.firstname}} {{this.lastname}}, {{#if principalInvestigator.organisation}}{{principalInvestigator.organisation}}{{else}}{{principalInvestigator.institution}}{{/if}}<br />
         {{/each}}
 
       </div>


### PR DESCRIPTION
## Description
This PR aims to address the rename of the `organisation` to `institution`. 
Therefore the new parameter name in the template is updated.

Due to the requirement for backward compatibility, both properties can be used. After the transition period is compleded the template will be simplified again to only support `institution` 