### PR TITLE
Prettier fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "jest": "^29.7.0",
         "lint-staged": "^15.2.0",
         "lodash": "^4.17.20",
-        "prettier": "^3.2.4",
+        "prettier": "3.2.4",
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2",
         "ts-node-dev": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest": "^29.7.0",
     "lint-staged": "^15.2.0",
     "lodash": "^4.17.20",
-    "prettier": "^3.2.4",
+    "prettier": "3.2.4",
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2",
     "ts-node-dev": "^2.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": [
       "ES2019",
       "esnext.asynciterable",
-      "DOM"
+      "DOM",
     ] /* Specify library files to be included in the compilation. */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -57,8 +57,8 @@
     /* Experimental Options */
     "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
     "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/*.spec.ts", "build", "coverage"]
+  "exclude": ["node_modules", "**/*.spec.ts", "build", "coverage"],
 }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->
Prettier was failing the checks on my release branch. This locks prettier to an exact version to prevent it failing unchanged files again due to formatting changes between its own releases. It also fixes the formatting warning on tsconfig.

Using an exact version is recommended by prettier in [their installation instructions](https://prettier.io/docs/en/install.html).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
Part of https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/1000

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
