### PR TITLE
chore: trigger the ESS deployment pipeline only for staging branch

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -51,6 +51,7 @@ jobs:
             type=gha,scope=${{ github.workflow }}:linux/arm64/v8
 
       - name: Trigger pipeline
+        if: ${{ steps.extract_branch.outputs.branch == 'staging' }} # Only trigger pipeline for staging branch
         uses: swapActions/trigger-useroffice-deployment@v1
         with:
           repository: ${{ github.repository }}


### PR DESCRIPTION
Our new development environment does not need to be triggered when a new version is released.