### PR TITLE
feat: optimise PDF Generation with concurrent template rendering and caching for file reads

### DIFF
--- a/src/__tests__/common/getTemplateFile.spec.ts
+++ b/src/__tests__/common/getTemplateFile.spec.ts
@@ -1,0 +1,33 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import { getTemplateFile } from '../../template/getTemplateFile';
+
+jest.mock('fs/promises');
+
+describe('getTemplateFile', () => {
+  const mockReadFile = readFile as jest.MockedFunction<typeof readFile>;
+  const templatesFolder = join(__dirname, '..', '..', '..', 'templates');
+  const fileName = 'test.txt';
+  const filePath = join(templatesFolder, fileName);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should read file content and cache it', async () => {
+    const fileContent = 'file content';
+    mockReadFile.mockResolvedValue(fileContent);
+
+    let content = await getTemplateFile(fileName);
+
+    expect(content).toBe(fileContent);
+
+    content = await getTemplateFile(fileName);
+
+    expect(content).toBe(fileContent);
+
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+    expect(mockReadFile).toHaveBeenCalledWith(filePath, 'utf-8');
+  });
+});

--- a/src/template/getTemplateFile.ts
+++ b/src/template/getTemplateFile.ts
@@ -1,0 +1,19 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+const templatesFolder = join(__dirname, '..', '..', 'templates');
+const fileCache: { [key: string]: string } = {};
+
+// Instead of reading the files every time, we cache the content
+export async function getTemplateFile(file: string): Promise<string> {
+  const filePath = join(templatesFolder, file);
+
+  if (fileCache[filePath]) {
+    return fileCache[filePath];
+  }
+
+  const content = await readFile(filePath, 'utf-8');
+  fileCache[filePath] = content;
+
+  return content;
+}

--- a/src/workflows/pdf/proposal/AutoProposalPdfFactory.ts
+++ b/src/workflows/pdf/proposal/AutoProposalPdfFactory.ts
@@ -242,14 +242,14 @@ export class AutoProposalPdfFactory extends PdfFactory<
     }
 
     try {
-      const renderedProposalHtml = await renderTemplate('proposal-main.hbs', {
-        proposal,
-        principalInvestigator,
-        coProposers,
-      });
-      const renderedHeaderFooter = await renderHeaderFooter(
-        proposal.proposalId
-      );
+      const [renderedProposalHtml, renderedHeaderFooter] = await Promise.all([
+        renderTemplate('proposal-main.hbs', {
+          proposal,
+          principalInvestigator,
+          coProposers,
+        }),
+        renderHeaderFooter(proposal.proposalId),
+      ]);
 
       const pdf = await generatePdfFromHtml(renderedProposalHtml, {
         pdfOptions: renderedHeaderFooter,
@@ -275,13 +275,15 @@ export class AutoProposalPdfFactory extends PdfFactory<
     }
 
     try {
-      const renderedProposalQuestion = await renderTemplate(
-        'questionary-step.hbs',
-        { steps: questionarySteps, genericTemplates, attachmentsFileMeta }
-      );
-      const renderedHeaderFooter = await renderHeaderFooter(
-        proposal.proposalId
-      );
+      const [renderedProposalQuestion, renderedHeaderFooter] =
+        await Promise.all([
+          renderTemplate('questionary-step.hbs', {
+            steps: questionarySteps,
+            genericTemplates,
+            attachmentsFileMeta,
+          }),
+          renderHeaderFooter(proposal.proposalId),
+        ]);
 
       const pdf = await generatePdfFromHtml(renderedProposalQuestion, {
         pdfOptions: renderedHeaderFooter,
@@ -310,12 +312,11 @@ export class AutoProposalPdfFactory extends PdfFactory<
     }
 
     try {
-      const renderedTechnicalReview = await renderTemplate(
-        'technical-review.hbs',
-        { technicalReviews }
-      );
-      const renderedHeaderFooter = await renderHeaderFooter(
-        proposal.proposalId
+      const [renderedTechnicalReview, renderedHeaderFooter] = await Promise.all(
+        [
+          renderTemplate('technical-review.hbs', { technicalReviews }),
+          renderHeaderFooter(proposal.proposalId),
+        ]
       );
 
       const pdf = await generatePdfFromHtml(renderedTechnicalReview, {
@@ -342,14 +343,15 @@ export class AutoProposalPdfFactory extends PdfFactory<
           return;
         }
 
-        const renderedProposalSample = await renderTemplate('sample.hbs', {
-          sample,
-          sampleQuestionaryFields,
-          attachmentsFileMeta,
-        });
-        const renderedHeaderFooter = await renderHeaderFooter(
-          proposal.proposalId
-        );
+        const [renderedProposalSample, renderedHeaderFooter] =
+          await Promise.all([
+            renderTemplate('sample.hbs', {
+              sample,
+              sampleQuestionaryFields,
+              attachmentsFileMeta,
+            }),
+            renderHeaderFooter(proposal.proposalId),
+          ]);
 
         const pdf = await generatePdfFromHtml(renderedProposalSample, {
           pdfOptions: renderedHeaderFooter,


### PR DESCRIPTION
Instead of reading the template files every time the HTML is compiled, we cache their contents and reuse them.