### PR TITLE
fix: exclude static service calls from tracing

### DIFF
--- a/src/config/tracing.ts
+++ b/src/config/tracing.ts
@@ -27,7 +27,21 @@ const otelSDK = new NodeSDK({
     }),
   ],
   instrumentations: [
-    new HttpInstrumentation(),
+    new HttpInstrumentation({
+      ignoreIncomingRequestHook: (req) => {
+        const url = req.url || '';
+
+        return (
+          url.startsWith('/static/') ||
+          url.endsWith('.css') ||
+          url.endsWith('.js') ||
+          url.endsWith('.png') ||
+          url.endsWith('.jpg') ||
+          url.endsWith('.ico') ||
+          url.endsWith('.svg')
+        );
+      },
+    }),
     new KnexInstrumentation({
       requireParentSpan: true,
       maxQueryLength: 100,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Excluding static service calls for clarity, performance, and cost-efficiency in observability setup.

## Motivation and Context

It helps to get cleaner service graphs and reduce the noise in traces

## How Has This Been Tested

Manually

## Fixes

https://github.com/UserOfficeProject/issue-tracker/issues/1433
<!--- Does this fix a user story, if so add a reference here -->

## Depends on

https://github.com/UserOfficeProject/user-office-core/pull/1110
<!--- Does this PR depend on another PR that should be merged first or at the same time -->

