### PR TITLE
feat: add title for users in default pdf template

### DIFF
--- a/templates/proposal-main.hbs
+++ b/templates/proposal-main.hbs
@@ -17,7 +17,7 @@
         <span class="bold">Proposal Team</span><br />
         <br />
         <span class="bold">Principal Investigator:</span><br />
-        {{principalInvestigator.firstname}} {{principalInvestigator.lastname}}<br />
+        {{#if principalInvestigator.title}}{{ principalInvestigator.title}}{{/if}} {{principalInvestigator.firstname}} {{principalInvestigator.lastname}}<br />
         {{#if principalInvestigator.organisation}}{{principalInvestigator.organisation}}{{else}}{{principalInvestigator.institution}}{{/if}}
         {{#if principalInvestigator.position}}<br />{{ principalInvestigator.position }}{{/if}}
         {{#if principalInvestigator.country}}<br />{{ principalInvestigator.country }}{{/if}}
@@ -25,7 +25,7 @@
 
         <span class="bold">Co-proposer:</span><br />
         {{#each coProposers}}
-          {{this.firstname}} {{this.lastname}}, {{#if this.organisation}}{{this.organisation}}{{else}}{{this.institution}}{{/if}}{{#if country}}, {{ country }}{{/if}}<br />
+          {{#if this.title}}{{ this.title}}{{/if}} {{this.firstname}} {{this.lastname}}, {{#if this.organisation}}{{this.organisation}}{{else}}{{this.institution}}{{/if}}{{#if country}}, {{ country }}{{/if}}<br />
         {{/each}}
 
       </div>


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR introduces the addition of user titles in the application for proposal pdfs.

## Motivation and Context

This change was necessary to provide better user identification and enhance user experience. It addresses the issue of users not having a title in the proposal pdf.

## How Has This Been Tested

Manually by generating pdfs

## Fixes

https://github.com/UserOfficeProject/issue-tracker/issues/1383

## Changes

Updated default pdf template

## Depends on

https://github.com/UserOfficeProject/user-office-core/pull/1130

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
