### PR TITLE
changes debug port

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "rm -rf ./build && tsc",
     "prod": "npm run build && env NODE_ENV=production node ./build/index.js",
     "dev": "ts-node-dev --rs --trace-warnings --respawn --exit-child ./src/index.ts",
-    "dev:docker": "npm install && ts-node-dev --inspect=0.0.0.0:9229 --rs --respawn ./src/index.ts",
+    "dev:docker": "npm install && ts-node-dev --inspect=0.0.0.0:9230 --rs --respawn ./src/index.ts",
     "debug": "ts-node-dev --rs --trace-warnings --inspect --respawn ./src/index.ts",
     "lint": "tsc --noEmit && eslint ./src --ext .js,.ts --quiet",
     "lint:all": "tsc --noEmit && eslint ./src --ext .js,.ts",


### PR DESCRIPTION
## Description

This PR changes the port used for debugging

## Motivation and Context

Currently port 9229 is used by the backend debugger. To avoid conflict, the debugger used by the factory should be changed.

## How Has This Been Tested

Tested manually

## Changes

`package.json` - port used by debugger changed from `9229` to `9230`

