### PR TITLE
fix: file retrieval connection leak on missing large object

### DIFF
--- a/src/dataSources/postgres/FileDataSource.ts
+++ b/src/dataSources/postgres/FileDataSource.ts
@@ -138,55 +138,43 @@ export default class PostgresFileDataSource implements FileDataSource {
       );
     }
 
-    const [transactionError] = await to(connection.query('BEGIN'));
-    if (transactionError) {
-      database.client.releaseConnection(connection);
+    try {
+      await connection.query('BEGIN');
 
-      throw new Error(`Could not begin transaction \n${transactionError}`);
-    }
-
-    const blobManager = new LargeObjectManager({ pg: connection });
-    const [streamErr, response] = await to(
-      blobManager.openAndReadableStreamAsync(oid)
-    );
-
-    if (streamErr || !response) {
-      await connection.query('ROLLBACK');
-      database.client.releaseConnection(connection);
-
-      throw new Error(
-        `Could not create readable stream \n${streamErr} ${response}`
+      const blobManager = new LargeObjectManager({ pg: connection });
+      const [streamErr, response] = await to(
+        blobManager.openAndReadableStreamAsync(oid)
       );
+
+      if (streamErr || !response) {
+        throw new Error(
+          `Could not create readable stream \n${streamErr} ${response}`
+        );
+      }
+
+      const [size, stream] = response;
+      logger.logInfo('Streaming large object', { oid, size });
+
+      await new Promise<void>((resolve, reject) => {
+        const fileStream = fs.createWriteStream(output);
+
+        stream.on('error', (streamError) =>
+          reject(new Error(`Stream error: ${streamError}`))
+        );
+        fileStream.on('error', (writeError) =>
+          reject(new Error(`File write error: ${writeError}`))
+        );
+        fileStream.on('finish', resolve);
+
+        stream.pipe(fileStream);
+      });
+
+      await connection.query('COMMIT');
+    } catch (error) {
+      await to(connection.query('ROLLBACK'));
+      throw error;
+    } finally {
+      database.client.releaseConnection(connection);
     }
-
-    const [size, stream] = response;
-    logger.logInfo('Streaming large object', { oid, size });
-
-    await new Promise<void>((resolve, reject) => {
-      const fileStream = fs.createWriteStream(output);
-
-      stream.on('error', async (streamError) => {
-        await to(connection.query('ROLLBACK'));
-        database.client.releaseConnection(connection);
-
-        reject(new Error(`Stream error: ${streamError}`));
-      });
-
-      fileStream.on('error', async (writeError) => {
-        await to(connection.query('ROLLBACK'));
-        database.client.releaseConnection(connection);
-
-        reject(new Error(`File write error: ${writeError}`));
-      });
-
-      fileStream.on('finish', async () => {
-        await to(connection.query('COMMIT'));
-        database.client.releaseConnection(connection);
-
-        resolve();
-      });
-
-      stream.pipe(fileStream);
-    });
   }
 }

--- a/src/dataSources/postgres/FileDataSource.ts
+++ b/src/dataSources/postgres/FileDataSource.ts
@@ -125,55 +125,67 @@ export default class PostgresFileDataSource implements FileDataSource {
   }
 
   private async retrieveBlob(oid: number, output: string): Promise<void> {
-    return new Promise(async (resolve, reject) => {
-      if (!output) reject('Output must be specified');
+    if (!output) {
+      throw new Error('Output must be specified');
+    }
 
-      const [connectionError, connection] = await to<Client>(
-        database.client.acquireConnection()
+    const [connectionError, connection] = await to(
+      database.client.acquireConnection() as Promise<Client | undefined>
+    );
+    if (connectionError || !connection) {
+      throw new Error(
+        `Error ocurred while establishing connection with database \n ${connectionError} ${connection}`
       );
-      if (connectionError) {
-        return reject(
-          `Could not establish connection with database \n ${connectionError}`
-        );
-      }
+    }
 
-      if (!connection) {
-        return reject('Could not obtain connection');
-      }
+    const [transactionError] = await to(connection.query('BEGIN'));
+    if (transactionError) {
+      database.client.releaseConnection(connection);
 
-      const [trxError] = await to(connection.query('BEGIN')); // start the transaction
-      if (trxError) {
+      throw new Error(`Could not begin transaction \n${transactionError}`);
+    }
+
+    const blobManager = new LargeObjectManager({ pg: connection });
+    const [streamErr, response] = await to(
+      blobManager.openAndReadableStreamAsync(oid)
+    );
+
+    if (streamErr || !response) {
+      await connection.query('ROLLBACK');
+      database.client.releaseConnection(connection);
+
+      throw new Error(
+        `Could not create readable stream \n${streamErr} ${response}`
+      );
+    }
+
+    const [size, stream] = response;
+    logger.logInfo('Streaming large object', { oid, size });
+
+    await new Promise<void>((resolve, reject) => {
+      const fileStream = fs.createWriteStream(output);
+
+      stream.on('error', async (streamError) => {
+        await to(connection.query('ROLLBACK'));
         database.client.releaseConnection(connection);
 
-        return reject(`Could not begin transaction \n${trxError}`);
-      }
-
-      const blobManager = new LargeObjectManager({ pg: connection });
-      const [err, readableStream] = await to(
-        blobManager.openAndReadableStreamAsync(oid)
-      );
-
-      if (err || !readableStream) {
-        connection.emit('error', connectionError);
-        database.client.releaseConnection(connection);
-
-        return reject(`Could not create readale stream \n${connectionError}`);
-      }
-
-      const [size, stream] = readableStream;
-
-      logger.logInfo(
-        `Streaming a large object with a total size of ${size}`,
-        {}
-      );
-
-      stream.on('end', function () {
-        connection?.query('COMMIT', () => resolve());
-        database.client.releaseConnection(connection);
+        reject(new Error(`Stream error: ${streamError}`));
       });
 
-      // Store it as an image
-      const fileStream = fs.createWriteStream(output);
+      fileStream.on('error', async (writeError) => {
+        await to(connection.query('ROLLBACK'));
+        database.client.releaseConnection(connection);
+
+        reject(new Error(`File write error: ${writeError}`));
+      });
+
+      fileStream.on('finish', async () => {
+        await to(connection.query('COMMIT'));
+        database.client.releaseConnection(connection);
+
+        resolve();
+      });
+
       stream.pipe(fileStream);
     });
   }

--- a/src/workflows/pdf/proposal/PregeneratedProposalPdfFactory.ts
+++ b/src/workflows/pdf/proposal/PregeneratedProposalPdfFactory.ts
@@ -62,13 +62,21 @@ export class PregeneratedPdfFactory extends PdfFactory<
 
   async downloadProposal(data: PregeneratedProposalPDFData): Promise<void> {
     const fileDataSource = new PostgresFileDataSource();
+    try {
+      const pdfPath = await fileDataSource.prepare(
+        data.proposal.fileId,
+        data.proposal.fileId
+      );
 
-    const pdfPath = await fileDataSource.prepare(
-      data.proposal.fileId,
-      data.proposal.fileId
-    );
+      this.emit('downloaded:proposal', pdfPath);
+      this.emit('countPages', pdfPath, 'proposal');
+    } catch (error) {
+      logger.logException(
+        'Failed to download pregenerated proposal PDF',
+        error
+      );
 
-    this.emit('downloaded:proposal', pdfPath);
-    this.emit('countPages', pdfPath, 'proposal');
+      this.emit('error', error, 'downloadProposal');
+    }
   }
 }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

When the Factory tries to download a large object with an oid that doesn't exist, it never returns the connection back to the pool which can lead to pool exhaustion. The logging currently hides the true cause of the error and the proposal frontend is left loading indefinitely.

This fixes the leak with improved connection handling that the proposal backend uses, that returns the connection after it fails. There are also some logging improvements.

## Motivation and Context

At STFC we copy our prod table data into dev and local but not all of the large objects, which means references to some files and pregenerated proposals don't exist. This bug (compounded with new readiness pod checks) is causing our dev pods to essentially break when attempting to download a pregenerated PDF, requiring a restart.

## How Has This Been Tested

- Tested downloading pregenerated PDFs that do/don't exist
- Tested downloading generated PDFs with file uploads

## Changes

- Rework retrieveBlob function
- Add error handling/logging to pregenerated flow

## Fixes

https://github.com/UserOfficeProject/issue-tracker/issues/1631